### PR TITLE
Automatically push changes to hf space

### DIFF
--- a/.github/workflows/check_size.yaml
+++ b/.github/workflows/check_size.yaml
@@ -1,0 +1,17 @@
+name: Check file size
+
+on:
+  pull_request:
+    branches: [main]
+
+  # to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  sync-to-hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check large files
+        uses: ActionsDesk/lfs-warning@v2.0
+        with:
+          filesizelimit: 10485760 # = 10MB, so we can sync to HF spaces

--- a/.github/workflows/sync_to_hub.yaml
+++ b/.github/workflows/sync_to_hub.yaml
@@ -1,0 +1,20 @@
+name: Sync to Hugging Face hub
+
+on:
+  push:
+    branches: [main]
+
+  # to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  sync-to-hub:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Push to hub
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: git push https://training-transformers-together:$HF_TOKEN@huggingface.co/spaces/training-transformers-together/demo main --force

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
+---
+title: NeurIPS demo landing page
+emoji: 🔥
+colorFrom: indigo
+colorTo: red
+sdk: static
+pinned: false
+---
 ### [training-transformers-together.github.io](https://training-transformers-together.github.io)
 


### PR DESCRIPTION
This PR proposes to add a github workflow to automatically push changes to main on https://huggingface.co/spaces/training-transformers-together/demo.

You can see the current rendering at https://huggingface.co/spaces/SaulLu/test-demo.

I don't know what is the internal logic of github to push changes to [VV](https://training-transformers-together.github.io/). So, without trying, I don't know if my additions can interfere (I'd be surprised if it can but we're never sure