### PR TITLE
Minor suggestion for the how to join section

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
   <h3 class="my-4">How do I join?</h3>
       <p> To participate in the demo training run, you need to follow these steps: </p>
       <ul class="mb-5">
-          <li>Log into your <a target="_blank" rel="noopener noreferrer" href="https://huggingface.co">huggingface</a> account,</li>
+          <li>Log into your <a target="_blank" rel="noopener noreferrer" href="https://huggingface.co/login">huggingface</a> account, or <a target="_blank" rel="noopener noreferrer" href="https://huggingface.co/join">create</a> one if you don't already have one</li></li>
           <li>Join our organization using this <a target="_blank" rel="noopener noreferrer" href="https://huggingface.co/organizations/training-transformers-together/share/otdYDceuoEIGEVXhrmYilPSnVUrnsrjJNz"><b>invite link</b></a></li>
           <li>Create a new User Access token at <a target="_blank" rel="noopener noreferrer" href="https://huggingface.co/settings/token">huggingface.co/settings/token</a> and copy it to the clipboard,</li>
           <li>Run the <a target="_blank" rel="noopener noreferrer" href="https://colab.research.google.com/github/training-transformers-together/training-transformers-together.github.io/blob/master/colab_gpu_starter.ipynb"><b>starter notebook</b></a>


### PR DESCRIPTION
As I watched someone try to follow the how to join, I noticed that it wasn't "obvious" that they had to create a Hugging Face account if they didn't have one.